### PR TITLE
Clarify transcoder spec

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -442,9 +442,7 @@ in the transcoder pool with the least delegated stake, the user successfully reg
 1. `T` calls `bondingManager.transcoder()` with percentage values for `rewardCut`, `feeShare` and `pricePerSegment`.
 2. If `T` has zero bonded stake delegated towards itself, abort.
 3. Set the rates for `T` as a transcoder.
-4. If the transcoder pool is full and `T`'s delegated stake is greater than that of the transcoder with the least delegated stake, evict the transcoder.
-5. Add `T` to the transcoder pool.
-6. `T` enters the `Registered` state.
+4. If the transcoder pool is full and `T`'s delegated stake is greater than that of the transcoder with the least delegated stake, evict the latter and add the former to the transcoder pool thereby transitioning `T` into the `Registered` state
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -442,7 +442,7 @@ in the transcoder pool with the least delegated stake, the user successfully reg
 1. `T` calls `bondingManager.transcoder()` with percentage values for `rewardCut`, `feeShare` and `pricePerSegment`.
 2. If `T` has zero bonded stake delegated towards itself, abort.
 3. Set the rates for `T` as a transcoder.
-4. If the transcoder pool is full and `T`'s delegated stake is greater than that of the transcoder with the least delegated stake, evict the transcoder. Else, abort.
+4. If the transcoder pool is full and `T`'s delegated stake is greater than that of the transcoder with the least delegated stake, evict the transcoder.
 5. Add `T` to the transcoder pool.
 6. `T` enters the `Registered` state.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -440,7 +440,7 @@ in the transcoder pool with the least delegated stake, the user successfully reg
 #### Algorithm
 
 1. `T` calls `bondingManager.transcoder()` with percentage values for `rewardCut`, `feeShare` and `pricePerSegment`.
-2. If `T` does not have non-zero bonded stake delegated towards itself, abort.
+2. If `T` has zero bonded stake delegated towards itself, abort.
 3. Set the rates for `T` as a transcoder.
 4. If the transcoder pool is full and `T`'s delegated stake is greater than that of the transcoder with the least delegated stake, evict the transcoder. Else, abort.
 5. Add `T` to the transcoder pool.


### PR DESCRIPTION
In SPEC.md:

- Removed a double negation for clarity
- In the 4th step of the transcoder algorithm, there was a confusion with the meaning of the word "abort". Contrary to the meaning of "abort" in step 2, where it means "revert the transaction", I believe the author meant "in the case where `T` delegated stake is less than that of the transcoder with the least delegated stake, don't add `T` to the pool and continue". There is no  `require` or `abort` after this condition in the [source code](https://github.com/livepeer/protocol/blob/master/contracts/bonding/BondingManager.sol#L239)  

