### PR TITLE
Change Deterministic encoding for Deterministic verification

### DIFF
--- a/STREAMFLOW.md
+++ b/STREAMFLOW.md
@@ -291,7 +291,7 @@ As with all work in the early field of blockchain based crypto economic protocol
 
 Work continues on the research to verify the likelihood that a GPU encoded segment represents the same content as the pre-encoded segment. This probabilistic and metrics driven approach has been shown in experiments and early research to yield accurate scores, however the suitability for actually slashing deposits based upon probabilistic outcomes is certainly debatable and requires further research.
 
-Deterministic encoding on the other hand can continue to be checked by a variety of verification schemes including Truebit, SGX based hardware verification, Oracles, or even trusted verifiers.
+Deterministic verification on the other hand can continue to be checked by a variety of verification schemes including Truebit, SGX based hardware verification, Oracles, or even trusted verifiers.
 
 ### Public Transcoder Pool Protocols
 


### PR DESCRIPTION
In the Open Research Areas section there is a subsection that is talking about Non Deterministic Verification. In the second paragraph at the beginning it is said deterministic encoding but I think the document is talking about Deterministic verification.