### PR TITLE
docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/STREAMFLOW.md
+++ b/STREAMFLOW.md
@@ -331,7 +331,7 @@ A formal migration path, checklist, and multiple observed testnet runs will be m
 
 In conclusion, the proposals contained within this document aim to shine a light on a scalable path for Livepeer's video infrastructure network - one that decouples the cost of using the Ethereum blockchain from the cost of using the network itself, and that provides existing scaled video developers with the reliability and performance that they require from their infrastructure.
 
-All feedback, ideas, and input are welcomed, so please do not hesitate to drop into [The Livepeer Forum](https://forum.livepeer.org) or [Discord Chat](https://discord.gg/RR4kFAh) to participate.
+All feedback, ideas, and input are welcomed, so please do not hesitate to drop into [The Livepeer Forum](https://forum.livepeer.org) or [Discord Chat](https://discord.gg/livepeer) to participate.
 
 
 ## Appendix ################################
@@ -364,5 +364,3 @@ For a full analysis and specification of the ticket data structures, double spen
 3. Ethereum Probabilistic Micropayments - Gustav Simonson - <https://medium.com/@gustav.simonsson/ethereum-probabilistic-micropayments-ae6e6cd85a06>
 4. Electronic Lottery Tickets as Micropayments - Ron Rivest - MIT Lab for Computer Science - <https://people.csail.mit.edu/rivest/pubs/Riv97b.pdf>
 5. Decentralized Anonymous Micropayments - A. Chiesa, M. Green, J. Liu, P. Miao, I. Miers and P. Mishra - <https://eprint.iacr.org/2016/1033.pdf>
-
-


### PR DESCRIPTION
This pull request updates the Discord invite URL from a temporary (expiring) link to a fixed (permanent) one to ensure long-term accessibility.
